### PR TITLE
Don't treat new pages as spam (closes #4)

### DIFF
--- a/readwiki.py
+++ b/readwiki.py
@@ -31,7 +31,7 @@ class WikiChange:
         if not self.hasData:
             return False
 
-        if self.change["old_revid"] == 0:
+        if self.change["type"] == "log":
             return True
 
         return False


### PR DESCRIPTION
Instead, just ignore changes of type "log".

We should probably rename the "spam" stuff, because this is not actually spam, but meta-stuff we don't want to tweet.